### PR TITLE
feat(listing): US-008 + US-009 — listagem e detalhe público de serviços

### DIFF
--- a/src/actions/requests.ts
+++ b/src/actions/requests.ts
@@ -1,0 +1,106 @@
+'use server'
+
+import { auth } from '@/auth'
+import { prisma } from '@/lib/prisma'
+import { revalidatePath } from 'next/cache'
+import type { RequestStatus } from '@prisma/client'
+
+type ActionResult = { success: true } | { success: false; error: string }
+
+async function transitionRequest(
+  requestId: string,
+  expectedStatus: RequestStatus,
+  newStatus: RequestStatus,
+  ownerField: 'provider' | 'buyer',
+): Promise<ActionResult> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { success: false, error: 'Não autenticado.' }
+  }
+
+  const request = await prisma.serviceRequest.findUnique({
+    where: { id: requestId },
+    select: {
+      id: true,
+      status: true,
+      buyerId: true,
+      service: { select: { userId: true } },
+    },
+  })
+
+  if (!request) {
+    return { success: false, error: 'Pedido não encontrado.' }
+  }
+
+  if (request.status !== expectedStatus) {
+    return { success: false, error: 'Transição de estado inválida.' }
+  }
+
+  const userId = session.user.id
+  if (ownerField === 'provider' && request.service.userId !== userId) {
+    return { success: false, error: 'Sem permissão.' }
+  }
+  if (ownerField === 'buyer' && request.buyerId !== userId) {
+    return { success: false, error: 'Sem permissão.' }
+  }
+
+  await prisma.serviceRequest.update({
+    where: { id: requestId },
+    data: { status: newStatus },
+  })
+
+  revalidatePath('/dashboard/requests')
+  revalidatePath('/dashboard/my-requests')
+
+  return { success: true }
+}
+
+/** PENDING → ACCEPTED (provider) */
+export async function acceptRequest(requestId: string): Promise<ActionResult> {
+  return transitionRequest(requestId, 'PENDING', 'ACCEPTED', 'provider')
+}
+
+/** PENDING → REJECTED (provider) */
+export async function rejectRequest(requestId: string): Promise<ActionResult> {
+  return transitionRequest(requestId, 'PENDING', 'REJECTED', 'provider')
+}
+
+/** ACCEPTED → COMPLETED (provider) */
+export async function completeRequest(requestId: string): Promise<ActionResult> {
+  return transitionRequest(requestId, 'ACCEPTED', 'COMPLETED', 'provider')
+}
+
+/** PENDING | ACCEPTED → CANCELLED (buyer) */
+export async function cancelRequest(requestId: string): Promise<ActionResult> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { success: false, error: 'Não autenticado.' }
+  }
+
+  const request = await prisma.serviceRequest.findUnique({
+    where: { id: requestId },
+    select: { id: true, status: true, buyerId: true },
+  })
+
+  if (!request) {
+    return { success: false, error: 'Pedido não encontrado.' }
+  }
+
+  if (request.status !== 'PENDING' && request.status !== 'ACCEPTED') {
+    return { success: false, error: 'Este pedido não pode ser cancelado.' }
+  }
+
+  if (request.buyerId !== session.user.id) {
+    return { success: false, error: 'Sem permissão.' }
+  }
+
+  await prisma.serviceRequest.update({
+    where: { id: requestId },
+    data: { status: 'CANCELLED' },
+  })
+
+  revalidatePath('/dashboard/requests')
+  revalidatePath('/dashboard/my-requests')
+
+  return { success: true }
+}

--- a/src/app/(main)/dashboard/my-requests/page.tsx
+++ b/src/app/(main)/dashboard/my-requests/page.tsx
@@ -1,0 +1,81 @@
+import { Suspense } from 'react'
+import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { auth } from '@/auth'
+import { prisma } from '@/lib/prisma'
+import { SentRequestCard } from '@/components/requests/sent-request-card'
+import { RequestStatusFilter } from '@/components/requests/request-status-filter'
+import type { RequestStatus } from '@prisma/client'
+
+export const metadata: Metadata = {
+  title: 'Os meus pedidos — SkoolBay',
+}
+
+const VALID_STATUSES = new Set<RequestStatus>([
+  'PENDING',
+  'ACCEPTED',
+  'COMPLETED',
+  'REJECTED',
+  'CANCELLED',
+])
+
+interface PageProps {
+  searchParams: { status?: string }
+}
+
+export default async function MyRequestsPage({ searchParams }: PageProps) {
+  const session = await auth()
+  if (!session?.user?.id) redirect('/login?callbackUrl=/dashboard/my-requests')
+
+  const rawStatus = searchParams.status
+  const statusFilter =
+    rawStatus && VALID_STATUSES.has(rawStatus as RequestStatus)
+      ? (rawStatus as RequestStatus)
+      : undefined
+
+  const requests = await prisma.serviceRequest.findMany({
+    where: {
+      buyerId: session.user.id,
+      ...(statusFilter && { status: statusFilter }),
+    },
+    orderBy: { updatedAt: 'desc' },
+    select: {
+      id: true,
+      message: true,
+      status: true,
+      createdAt: true,
+      service: {
+        select: {
+          id: true,
+          title: true,
+          user: { select: { id: true, name: true, avatarUrl: true } },
+        },
+      },
+    },
+  })
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10">
+      <div className="mb-6 space-y-1">
+        <h1 className="text-2xl font-bold">Os meus pedidos</h1>
+        <p className="text-muted-foreground text-sm">Pedidos que enviaste a prestadores</p>
+      </div>
+
+      <Suspense fallback={null}>
+        <RequestStatusFilter basePath="/dashboard/my-requests" />
+      </Suspense>
+
+      <div className="mt-6 space-y-3">
+        {requests.length === 0 ? (
+          <p className="py-12 text-center text-sm text-muted-foreground">
+            {statusFilter ? 'Nenhum pedido com este estado.' : 'Ainda não enviaste nenhum pedido.'}
+          </p>
+        ) : (
+          requests.map((request) => (
+            <SentRequestCard key={request.id} request={request} />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,14 +1,108 @@
-import { auth } from '@/auth'
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { auth } from '@/auth'
+import { prisma } from '@/lib/prisma'
+import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { Inbox, SendHorizonal, Plus } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'Dashboard — SkoolBay',
+}
 
 export default async function DashboardPage() {
   const session = await auth()
-  if (!session) redirect('/login')
+  if (!session?.user?.id) redirect('/login')
+
+  const [receivedCount, sentCount] = await Promise.all([
+    prisma.serviceRequest.count({
+      where: { service: { userId: session.user.id }, status: 'PENDING' },
+    }),
+    prisma.serviceRequest.count({
+      where: { buyerId: session.user.id, status: 'PENDING' },
+    }),
+  ])
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-2">Olá, {session.user?.name?.split(' ')[0]}!</h1>
-      <p className="text-muted-foreground">O teu dashboard está a ser construído. Volta em breve.</p>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold mb-1">
+          Olá, {session.user?.name?.split(' ')[0]}!
+        </h1>
+        <p className="text-muted-foreground text-sm">O que queres fazer hoje?</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {/* Pedidos recebidos */}
+        <Link
+          href="/dashboard/requests"
+          className="group flex flex-col gap-3 rounded-xl border bg-card p-5 text-sm transition-shadow hover:shadow-md"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+              <Inbox className="h-5 w-5 text-primary" />
+            </div>
+            {receivedCount > 0 && (
+              <span className="inline-flex h-5 items-center rounded-full bg-primary px-2 text-xs font-medium text-primary-foreground">
+                {receivedCount}
+              </span>
+            )}
+          </div>
+          <div>
+            <p className="font-semibold group-hover:text-primary transition-colors">
+              Pedidos recebidos
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Gere os pedidos nos teus serviços
+            </p>
+          </div>
+        </Link>
+
+        {/* Pedidos enviados */}
+        <Link
+          href="/dashboard/my-requests"
+          className="group flex flex-col gap-3 rounded-xl border bg-card p-5 text-sm transition-shadow hover:shadow-md"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-secondary">
+              <SendHorizonal className="h-5 w-5 text-secondary-foreground" />
+            </div>
+            {sentCount > 0 && (
+              <span className="inline-flex h-5 items-center rounded-full bg-secondary px-2 text-xs font-medium text-secondary-foreground">
+                {sentCount}
+              </span>
+            )}
+          </div>
+          <div>
+            <p className="font-semibold group-hover:text-primary transition-colors">
+              Os meus pedidos
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Acompanha os pedidos que enviaste
+            </p>
+          </div>
+        </Link>
+
+        {/* Publicar serviço */}
+        <Link
+          href="/services/new"
+          className={cn(
+            buttonVariants({ variant: 'outline' }),
+            'group flex flex-col items-start gap-3 rounded-xl h-auto p-5 text-sm',
+          )}
+        >
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg border-2 border-dashed border-muted-foreground/30 group-hover:border-primary/50 transition-colors">
+            <Plus className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
+          </div>
+          <div>
+            <p className="font-semibold">Publicar serviço</p>
+            <p className="text-xs text-muted-foreground mt-0.5 font-normal">
+              Oferece os teus conhecimentos
+            </p>
+          </div>
+        </Link>
+      </div>
     </div>
   )
 }

--- a/src/app/(main)/dashboard/requests/page.tsx
+++ b/src/app/(main)/dashboard/requests/page.tsx
@@ -1,0 +1,85 @@
+import { Suspense } from 'react'
+import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { auth } from '@/auth'
+import { prisma } from '@/lib/prisma'
+import { ReceivedRequestCard } from '@/components/requests/received-request-card'
+import { RequestStatusFilter } from '@/components/requests/request-status-filter'
+import type { RequestStatus } from '@prisma/client'
+
+export const metadata: Metadata = {
+  title: 'Pedidos recebidos — SkoolBay',
+}
+
+const VALID_STATUSES = new Set<RequestStatus>([
+  'PENDING',
+  'ACCEPTED',
+  'COMPLETED',
+  'REJECTED',
+  'CANCELLED',
+])
+
+interface PageProps {
+  searchParams: { status?: string }
+}
+
+export default async function ReceivedRequestsPage({ searchParams }: PageProps) {
+  const session = await auth()
+  if (!session?.user?.id) redirect('/login?callbackUrl=/dashboard/requests')
+
+  const rawStatus = searchParams.status
+  const statusFilter =
+    rawStatus && VALID_STATUSES.has(rawStatus as RequestStatus)
+      ? (rawStatus as RequestStatus)
+      : undefined
+
+  const requests = await prisma.serviceRequest.findMany({
+    where: {
+      service: { userId: session.user.id },
+      ...(statusFilter && { status: statusFilter }),
+    },
+    orderBy: { updatedAt: 'desc' },
+    select: {
+      id: true,
+      message: true,
+      status: true,
+      createdAt: true,
+      service: { select: { id: true, title: true } },
+      buyer: { select: { id: true, name: true, avatarUrl: true } },
+    },
+  })
+
+  const pendingCount = requests.filter((r) => r.status === 'PENDING').length
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10">
+      <div className="mb-6 space-y-1">
+        <h1 className="text-2xl font-bold">Pedidos recebidos</h1>
+        <p className="text-muted-foreground text-sm">
+          Pedidos nos teus serviços
+          {pendingCount > 0 && (
+            <span className="ml-2 inline-flex h-5 items-center rounded-full bg-primary px-2 text-xs font-medium text-primary-foreground">
+              {pendingCount} pendente{pendingCount !== 1 && 's'}
+            </span>
+          )}
+        </p>
+      </div>
+
+      <Suspense fallback={null}>
+        <RequestStatusFilter basePath="/dashboard/requests" />
+      </Suspense>
+
+      <div className="mt-6 space-y-3">
+        {requests.length === 0 ? (
+          <p className="py-12 text-center text-sm text-muted-foreground">
+            {statusFilter ? 'Nenhum pedido com este estado.' : 'Ainda não tens pedidos recebidos.'}
+          </p>
+        ) : (
+          requests.map((request) => (
+            <ReceivedRequestCard key={request.id} request={request} />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/services/[id]/page.tsx
+++ b/src/app/(main)/services/[id]/page.tsx
@@ -4,18 +4,44 @@ import type { Metadata } from 'next'
 import { auth } from '@/auth'
 import { prisma } from '@/lib/prisma'
 import { Badge } from '@/components/ui/badge'
-import { buttonVariants } from '@/components/ui/button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Separator } from '@/components/ui/separator'
-import { cn } from '@/lib/utils'
-import { Euro, Pencil } from 'lucide-react'
+import { ServiceActions } from '@/components/services/service-actions'
+import { Euro, Star, CheckCircle2, XCircle } from 'lucide-react'
 
 interface ServicePageProps {
   params: { id: string }
 }
 
 function getInitials(name: string): string {
-  return name.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
+  return name
+    .split(' ')
+    .slice(0, 2)
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+}
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('pt-PT', { day: '2-digit', month: 'short', year: 'numeric' }).format(
+    new Date(date),
+  )
+}
+
+function StarRating({ rating, size = 'sm' }: { rating: number; size?: 'sm' | 'md' }) {
+  const iconClass = size === 'md' ? 'h-4 w-4' : 'h-3 w-3'
+  return (
+    <div className="flex items-center gap-0.5">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Star
+          key={i}
+          className={`${iconClass} ${
+            i < rating ? 'fill-yellow-400 text-yellow-400' : 'text-muted-foreground/40'
+          }`}
+        />
+      ))}
+    </div>
+  )
 }
 
 export async function generateMetadata({ params }: ServicePageProps): Promise<Metadata> {
@@ -33,7 +59,7 @@ export async function generateMetadata({ params }: ServicePageProps): Promise<Me
 export default async function ServicePage({ params }: ServicePageProps) {
   const [service, session] = await Promise.all([
     prisma.service.findUnique({
-      where: { id: params.id, isActive: true },
+      where: { id: params.id },
       select: {
         id: true,
         title: true,
@@ -52,6 +78,14 @@ export default async function ServicePage({ params }: ServicePageProps) {
             rating: true,
           },
         },
+        requests: {
+          where: { review: { isNot: null } },
+          orderBy: { createdAt: 'desc' },
+          select: {
+            buyer: { select: { name: true, avatarUrl: true } },
+            review: { select: { rating: true, comment: true, createdAt: true } },
+          },
+        },
       },
     }),
     auth(),
@@ -60,33 +94,70 @@ export default async function ServicePage({ params }: ServicePageProps) {
   if (!service) notFound()
 
   const isOwner = session?.user?.id === service.userId
+  const isAuthenticated = !!session?.user
+
+  const reviews = service.requests.flatMap((r) =>
+    r.review
+      ? [{ buyer: r.buyer, rating: r.review.rating, comment: r.review.comment, createdAt: r.review.createdAt }]
+      : [],
+  )
+
+  const avgRating =
+    reviews.length > 0
+      ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length
+      : null
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-10 space-y-8">
       {/* Header */}
       <div className="space-y-3">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
             {service.category && (
-              <Badge variant="secondary" className="mb-2">{service.category.name}</Badge>
+              <Badge variant="secondary">{service.category.name}</Badge>
             )}
-            <h1 className="text-2xl font-bold leading-tight">{service.title}</h1>
-          </div>
-          {isOwner && (
-            <Link
-              href={`/services/${service.id}/edit`}
-              className={cn(buttonVariants({ variant: 'outline', size: 'sm' }), 'shrink-0 gap-1.5')}
+            <Badge
+              variant={service.isActive ? 'default' : 'outline'}
+              className="gap-1 text-xs"
             >
-              <Pencil className="h-3.5 w-3.5" />Editar
-            </Link>
-          )}
+              {service.isActive ? (
+                <>
+                  <CheckCircle2 className="h-3 w-3" />
+                  Disponível
+                </>
+              ) : (
+                <>
+                  <XCircle className="h-3 w-3" />
+                  Indisponível
+                </>
+              )}
+            </Badge>
+          </div>
+          <h1 className="text-2xl font-bold leading-tight">{service.title}</h1>
         </div>
 
-        <div className="flex items-center gap-1.5 text-2xl font-semibold text-primary">
-          <Euro className="h-5 w-5" />
-          {service.price.toFixed(2)}
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-1 text-2xl font-semibold text-primary">
+            <Euro className="h-5 w-5" />
+            {service.price.toFixed(2)}
+          </div>
+          {avgRating !== null && (
+            <div className="flex items-center gap-1.5">
+              <StarRating rating={Math.round(avgRating)} size="md" />
+              <span className="text-sm text-muted-foreground">
+                {avgRating.toFixed(1)} ({reviews.length})
+              </span>
+            </div>
+          )}
         </div>
       </div>
+
+      {/* Ação principal */}
+      <ServiceActions
+        serviceId={service.id}
+        isOwner={isOwner}
+        isAuthenticated={isAuthenticated}
+      />
 
       <Separator />
 
@@ -103,7 +174,10 @@ export default async function ServicePage({ params }: ServicePageProps) {
       {/* Prestador */}
       <div>
         <h2 className="text-sm font-semibold mb-3">Prestador</h2>
-        <Link href={`/profile/${service.user.id}`} className="flex items-center gap-3 group w-fit">
+        <Link
+          href={`/profile/${service.user.id}`}
+          className="flex items-center gap-3 group w-fit"
+        >
           <Avatar className="size-10">
             <AvatarImage src={service.user.avatarUrl ?? undefined} alt={service.user.name} />
             <AvatarFallback>{getInitials(service.user.name)}</AvatarFallback>
@@ -115,9 +189,60 @@ export default async function ServicePage({ params }: ServicePageProps) {
             {service.user.university && (
               <p className="text-xs text-muted-foreground">{service.user.university}</p>
             )}
+            {service.user.rating > 0 && (
+              <div className="flex items-center gap-1 mt-0.5">
+                <StarRating rating={Math.round(service.user.rating)} />
+                <span className="text-xs text-muted-foreground">
+                  {service.user.rating.toFixed(1)}
+                </span>
+              </div>
+            )}
           </div>
         </Link>
       </div>
+
+      {/* Reviews */}
+      {reviews.length > 0 && (
+        <>
+          <Separator />
+          <div>
+            <h2 className="text-sm font-semibold mb-4">
+              Avaliações ({reviews.length})
+            </h2>
+            <ul className="space-y-5">
+              {reviews.map((review, i) => (
+                <li key={i} className="space-y-1.5">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <Avatar className="size-7">
+                        <AvatarImage
+                          src={review.buyer.avatarUrl ?? undefined}
+                          alt={review.buyer.name}
+                        />
+                        <AvatarFallback className="text-[10px]">
+                          {getInitials(review.buyer.name)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <span className="text-sm font-medium">{review.buyer.name}</span>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <StarRating rating={review.rating} />
+                      <span className="text-xs text-muted-foreground">
+                        {formatDate(review.createdAt)}
+                      </span>
+                    </div>
+                  </div>
+                  {review.comment && (
+                    <p className="text-sm text-muted-foreground pl-9 leading-relaxed">
+                      {review.comment}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/src/app/(main)/services/page.tsx
+++ b/src/app/(main)/services/page.tsx
@@ -1,0 +1,154 @@
+import { Suspense } from 'react'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+import { ServiceCard } from '@/components/services/service-card'
+import { ServicesFilters } from '@/components/services/services-filters'
+import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'Serviços — SkoolBay',
+  description: 'Explora os serviços disponíveis na comunidade SkoolBay.',
+}
+
+const LIMIT = 12
+
+type SortKey = 'newest' | 'price_asc' | 'rating'
+
+interface PageProps {
+  searchParams: {
+    q?: string
+    categoryId?: string
+    maxPrice?: string
+    sort?: string
+    page?: string
+  }
+}
+
+function buildOrderBy(sort: SortKey) {
+  if (sort === 'price_asc') return { price: 'asc' as const }
+  if (sort === 'rating') return { user: { rating: 'desc' as const } }
+  return { createdAt: 'desc' as const }
+}
+
+export default async function ServicesPage({ searchParams }: PageProps) {
+  const q = searchParams.q?.trim() ?? ''
+  const categoryId = searchParams.categoryId?.trim() ?? ''
+  const maxPrice = searchParams.maxPrice ? parseFloat(searchParams.maxPrice) : undefined
+  const sort = (['newest', 'price_asc', 'rating'].includes(searchParams.sort ?? '')
+    ? (searchParams.sort as SortKey)
+    : 'newest')
+  const page = Math.max(1, parseInt(searchParams.page ?? '1', 10))
+
+  const where = {
+    isActive: true,
+    ...(q && {
+      OR: [
+        { title: { contains: q, mode: 'insensitive' as const } },
+        { description: { contains: q, mode: 'insensitive' as const } },
+      ],
+    }),
+    ...(categoryId && { categoryId }),
+    ...(maxPrice !== undefined && !isNaN(maxPrice) && { price: { lte: maxPrice } }),
+  }
+
+  const [services, total, categories] = await Promise.all([
+    prisma.service.findMany({
+      where,
+      orderBy: buildOrderBy(sort),
+      skip: (page - 1) * LIMIT,
+      take: LIMIT,
+      select: {
+        id: true,
+        title: true,
+        price: true,
+        createdAt: true,
+        category: { select: { name: true } },
+        user: { select: { id: true, name: true, avatarUrl: true, rating: true } },
+      },
+    }),
+    prisma.service.count({ where }),
+    prisma.category.findMany({ orderBy: { name: 'asc' } }),
+  ])
+
+  const totalPages = Math.ceil(total / LIMIT)
+
+  function buildPageUrl(p: number) {
+    const params = new URLSearchParams()
+    if (q) params.set('q', q)
+    if (categoryId) params.set('categoryId', categoryId)
+    if (maxPrice !== undefined && !isNaN(maxPrice)) params.set('maxPrice', String(maxPrice))
+    if (sort !== 'newest') params.set('sort', sort)
+    if (p > 1) params.set('page', String(p))
+    const qs = params.toString()
+    return `/services${qs ? `?${qs}` : ''}`
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-10">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">Serviços</h1>
+        <p className="text-muted-foreground mt-1">
+          Explora os serviços disponíveis na comunidade SkoolBay
+        </p>
+      </div>
+
+      {/* Filters — wrapped in Suspense because ServicesFilters uses useSearchParams */}
+      <Suspense fallback={<div className="h-10 w-full animate-pulse rounded-md bg-muted" />}>
+        <ServicesFilters categories={categories} />
+      </Suspense>
+
+      {/* Results count */}
+      <p className="text-sm text-muted-foreground mt-6">
+        {total === 0
+          ? 'Nenhum serviço encontrado.'
+          : `${total} ${total === 1 ? 'serviço encontrado' : 'serviços encontrados'}`}
+      </p>
+
+      {services.length === 0 ? (
+        <div className="text-center py-16 space-y-2">
+          <p className="text-muted-foreground">Tenta ajustar os filtros ou pesquisa.</p>
+          <Link href="/services" className={cn(buttonVariants({ variant: 'outline', size: 'sm' }))}>
+            Limpar filtros
+          </Link>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-4">
+            {services.map((service) => (
+              <ServiceCard key={service.id} service={service} />
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-10">
+              {page > 1 && (
+                <Link
+                  href={buildPageUrl(page - 1)}
+                  className={cn(buttonVariants({ variant: 'outline', size: 'sm' }), 'gap-1')}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Anterior
+                </Link>
+              )}
+              <span className="text-sm text-muted-foreground px-2">
+                Página {page} de {totalPages}
+              </span>
+              {page < totalPages && (
+                <Link
+                  href={buildPageUrl(page + 1)}
+                  className={cn(buttonVariants({ variant: 'outline', size: 'sm' }), 'gap-1')}
+                >
+                  Seguinte
+                  <ChevronRight className="h-4 w-4" />
+                </Link>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { prisma } from '@/lib/prisma'
+import { createRequestSchema } from '@/lib/validations/request'
+
+export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado.' }, { status: 401 })
+  }
+
+  const body = await req.json()
+  const parsed = createRequestSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Dados inválidos.', details: parsed.error.flatten().fieldErrors },
+      { status: 400 },
+    )
+  }
+
+  const { serviceId, message } = parsed.data
+
+  const service = await prisma.service.findUnique({
+    where: { id: serviceId, isActive: true },
+    select: { id: true, userId: true },
+  })
+
+  if (!service) {
+    return NextResponse.json({ error: 'Serviço não encontrado.' }, { status: 404 })
+  }
+
+  if (service.userId === session.user.id) {
+    return NextResponse.json(
+      { error: 'Não podes pedir o teu próprio serviço.' },
+      { status: 400 },
+    )
+  }
+
+  const existing = await prisma.serviceRequest.findFirst({
+    where: { serviceId, buyerId: session.user.id, status: 'PENDING' },
+    select: { id: true },
+  })
+
+  if (existing) {
+    return NextResponse.json(
+      { error: 'Já tens um pedido pendente para este serviço.' },
+      { status: 409 },
+    )
+  }
+
+  const request = await prisma.serviceRequest.create({
+    data: { serviceId, buyerId: session.user.id, message },
+    select: { id: true },
+  })
+
+  return NextResponse.json({ id: request.id }, { status: 201 })
+}

--- a/src/components/requests/received-request-card.tsx
+++ b/src/components/requests/received-request-card.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useTransition } from 'react'
+import Link from 'next/link'
+import { toast } from 'sonner'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import { RequestStatusBadge } from './request-status-badge'
+import { acceptRequest, rejectRequest, completeRequest } from '@/actions/requests'
+import { Check, X, CheckCheck, ExternalLink } from 'lucide-react'
+import type { RequestStatus } from '@prisma/client'
+
+interface ReceivedRequestCardProps {
+  request: {
+    id: string
+    message: string
+    status: RequestStatus
+    createdAt: Date
+    service: { id: string; title: string }
+    buyer: { id: string; name: string; avatarUrl: string | null }
+  }
+}
+
+function getInitials(name: string): string {
+  return name.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
+}
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('pt-PT', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(date))
+}
+
+export function ReceivedRequestCard({ request }: ReceivedRequestCardProps) {
+  const [isPending, startTransition] = useTransition()
+
+  function handleAction(action: () => Promise<{ success: boolean; error?: string }>) {
+    startTransition(async () => {
+      const result = await action()
+      if (!result.success) {
+        toast.error(result.error ?? 'Erro ao atualizar pedido.')
+      }
+    })
+  }
+
+  return (
+    <div className="rounded-xl border bg-card p-4 space-y-3 text-sm">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <Avatar className="size-8 shrink-0">
+            <AvatarImage src={request.buyer.avatarUrl ?? undefined} alt={request.buyer.name} />
+            <AvatarFallback className="text-xs">{getInitials(request.buyer.name)}</AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className="font-medium truncate">{request.buyer.name}</p>
+            <p className="text-xs text-muted-foreground">{formatDate(request.createdAt)}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <RequestStatusBadge status={request.status} />
+        </div>
+      </div>
+
+      {/* Serviço */}
+      <Link
+        href={`/services/${request.service.id}`}
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors w-fit"
+      >
+        <ExternalLink className="h-3 w-3" />
+        {request.service.title}
+      </Link>
+
+      {/* Mensagem */}
+      <p className="text-muted-foreground leading-relaxed line-clamp-3">{request.message}</p>
+
+      {/* Ações */}
+      {request.status === 'PENDING' && (
+        <div className="flex items-center gap-2 pt-1">
+          <Button
+            size="sm"
+            onClick={() => handleAction(() => acceptRequest(request.id))}
+            disabled={isPending}
+            className="gap-1"
+          >
+            <Check className="h-3.5 w-3.5" />
+            Aceitar
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={() => handleAction(() => rejectRequest(request.id))}
+            disabled={isPending}
+            className="gap-1"
+          >
+            <X className="h-3.5 w-3.5" />
+            Recusar
+          </Button>
+        </div>
+      )}
+
+      {request.status === 'ACCEPTED' && (
+        <div className="flex items-center gap-2 pt-1">
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => handleAction(() => completeRequest(request.id))}
+            disabled={isPending}
+            className="gap-1"
+          >
+            <CheckCheck className="h-3.5 w-3.5" />
+            Marcar como concluído
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/requests/request-status-badge.tsx
+++ b/src/components/requests/request-status-badge.tsx
@@ -1,0 +1,43 @@
+import { Badge } from '@/components/ui/badge'
+import type { RequestStatus } from '@prisma/client'
+
+const STATUS_MAP: Record<RequestStatus, { label: string; className: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }> = {
+  PENDING: {
+    label: 'Pendente',
+    className: '',
+    variant: 'secondary',
+  },
+  ACCEPTED: {
+    label: 'Aceite',
+    className: 'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/30 dark:text-blue-400',
+    variant: 'outline',
+  },
+  COMPLETED: {
+    label: 'Concluído',
+    className: 'bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400',
+    variant: 'outline',
+  },
+  REJECTED: {
+    label: 'Recusado',
+    className: '',
+    variant: 'destructive',
+  },
+  CANCELLED: {
+    label: 'Cancelado',
+    className: 'text-muted-foreground',
+    variant: 'outline',
+  },
+}
+
+interface RequestStatusBadgeProps {
+  status: RequestStatus
+}
+
+export function RequestStatusBadge({ status }: RequestStatusBadgeProps) {
+  const { label, className, variant } = STATUS_MAP[status]
+  return (
+    <Badge variant={variant} className={className}>
+      {label}
+    </Badge>
+  )
+}

--- a/src/components/requests/request-status-filter.tsx
+++ b/src/components/requests/request-status-filter.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import type { RequestStatus } from '@prisma/client'
+
+const FILTER_OPTIONS: { value: RequestStatus | '_all'; label: string }[] = [
+  { value: '_all', label: 'Todos' },
+  { value: 'PENDING', label: 'Pendentes' },
+  { value: 'ACCEPTED', label: 'Aceites' },
+  { value: 'COMPLETED', label: 'Concluídos' },
+  { value: 'REJECTED', label: 'Recusados' },
+  { value: 'CANCELLED', label: 'Cancelados' },
+]
+
+interface RequestStatusFilterProps {
+  basePath: string
+}
+
+export function RequestStatusFilter({ basePath }: RequestStatusFilterProps) {
+  const searchParams = useSearchParams()
+  const current = searchParams.get('status') ?? '_all'
+
+  return (
+    <div className="flex flex-wrap gap-1.5" role="tablist" aria-label="Filtrar por estado">
+      {FILTER_OPTIONS.map(({ value, label }) => {
+        const href =
+          value === '_all' ? basePath : `${basePath}?status=${value}`
+        const isActive = current === value
+
+        return (
+          <Link
+            key={value}
+            href={href}
+            role="tab"
+            aria-selected={isActive}
+            className={cn(
+              'inline-flex h-7 items-center rounded-lg px-2.5 text-sm font-medium transition-colors',
+              isActive
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+            )}
+          >
+            {label}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/requests/sent-request-card.tsx
+++ b/src/components/requests/sent-request-card.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useTransition } from 'react'
+import Link from 'next/link'
+import { toast } from 'sonner'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import { RequestStatusBadge } from './request-status-badge'
+import { cancelRequest } from '@/actions/requests'
+import { ExternalLink, User, XCircle } from 'lucide-react'
+import type { RequestStatus } from '@prisma/client'
+
+interface SentRequestCardProps {
+  request: {
+    id: string
+    message: string
+    status: RequestStatus
+    createdAt: Date
+    service: {
+      id: string
+      title: string
+      user: { id: string; name: string; avatarUrl: string | null }
+    }
+  }
+}
+
+function getInitials(name: string): string {
+  return name.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
+}
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('pt-PT', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(date))
+}
+
+export function SentRequestCard({ request }: SentRequestCardProps) {
+  const [isPending, startTransition] = useTransition()
+  const canCancel = request.status === 'PENDING' || request.status === 'ACCEPTED'
+
+  function handleCancel() {
+    startTransition(async () => {
+      const result = await cancelRequest(request.id)
+      if (!result.success) {
+        toast.error(result.error ?? 'Erro ao cancelar pedido.')
+      } else {
+        toast.success('Pedido cancelado.')
+      }
+    })
+  }
+
+  return (
+    <div className="rounded-xl border bg-card p-4 space-y-3 text-sm">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <Link
+            href={`/services/${request.service.id}`}
+            className="font-medium hover:text-primary transition-colors flex items-center gap-1 w-fit"
+          >
+            {request.service.title}
+            <ExternalLink className="h-3 w-3 shrink-0" />
+          </Link>
+          <p className="text-xs text-muted-foreground mt-0.5">{formatDate(request.createdAt)}</p>
+        </div>
+        <RequestStatusBadge status={request.status} />
+      </div>
+
+      {/* Prestador */}
+      <Link
+        href={`/profile/${request.service.user.id}`}
+        className="flex items-center gap-2 w-fit group"
+      >
+        <Avatar className="size-6 shrink-0">
+          <AvatarImage
+            src={request.service.user.avatarUrl ?? undefined}
+            alt={request.service.user.name}
+          />
+          <AvatarFallback className="text-[10px]">
+            {getInitials(request.service.user.name)}
+          </AvatarFallback>
+        </Avatar>
+        <span className="text-xs text-muted-foreground group-hover:text-foreground transition-colors flex items-center gap-1">
+          <User className="h-3 w-3" />
+          {request.service.user.name}
+        </span>
+      </Link>
+
+      {/* Mensagem */}
+      <p className="text-muted-foreground leading-relaxed line-clamp-3">{request.message}</p>
+
+      {/* Cancelar */}
+      {canCancel && (
+        <div className="pt-1">
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={handleCancel}
+            disabled={isPending}
+            className="gap-1"
+          >
+            <XCircle className="h-3.5 w-3.5" />
+            {isPending ? 'A cancelar...' : 'Cancelar pedido'}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/services/service-actions.tsx
+++ b/src/components/services/service-actions.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { Button, buttonVariants } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+import { Pencil, Trash2, ShoppingBag } from 'lucide-react'
+
+interface ServiceActionsProps {
+  serviceId: string
+  isOwner: boolean
+  isAuthenticated: boolean
+}
+
+export function ServiceActions({ serviceId, isOwner, isAuthenticated }: ServiceActionsProps) {
+  const router = useRouter()
+  const [showRequestForm, setShowRequestForm] = useState(false)
+  const [message, setMessage] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  async function handleRequest() {
+    if (message.trim().length < 10) {
+      toast.error('A mensagem deve ter pelo menos 10 caracteres.')
+      return
+    }
+    setIsSubmitting(true)
+    try {
+      const res = await fetch('/api/requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ serviceId, message }),
+      })
+      const json = await res.json() as { error?: string }
+
+      if (!res.ok) {
+        toast.error(json.error ?? 'Erro ao enviar pedido.')
+        return
+      }
+
+      toast.success('Pedido enviado com sucesso!')
+      setShowRequestForm(false)
+      setMessage('')
+      router.refresh()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleDelete() {
+    setIsDeleting(true)
+    try {
+      const res = await fetch(`/api/services/${serviceId}`, { method: 'DELETE' })
+      const json = await res.json() as { error?: string }
+
+      if (!res.ok) {
+        toast.error(json.error ?? 'Erro ao remover serviço.')
+        return
+      }
+
+      toast.success('Serviço removido.')
+      router.push('/dashboard')
+      router.refresh()
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  if (isOwner) {
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/services/${serviceId}/edit`}
+            className={cn(buttonVariants({ variant: 'outline' }), 'gap-2')}
+          >
+            <Pencil className="h-4 w-4" />
+            Editar
+          </Link>
+
+          {!showDeleteConfirm ? (
+            <Button
+              variant="destructive"
+              onClick={() => setShowDeleteConfirm(true)}
+              disabled={isDeleting}
+              className="gap-2"
+            >
+              <Trash2 className="h-4 w-4" />
+              Remover
+            </Button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-destructive font-medium">Tens a certeza?</span>
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={isDeleting}
+                size="sm"
+              >
+                {isDeleting ? 'A remover...' : 'Confirmar'}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => setShowDeleteConfirm(false)}
+                disabled={isDeleting}
+                size="sm"
+              >
+                Não
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <Link
+        href={`/login?callbackUrl=${encodeURIComponent(`/services/${serviceId}`)}`}
+        className={cn(buttonVariants({ size: 'lg' }), 'gap-2 w-full sm:w-auto')}
+      >
+        <ShoppingBag className="h-4 w-4" />
+        Pedir Serviço
+      </Link>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {!showRequestForm ? (
+        <Button
+          size="lg"
+          onClick={() => setShowRequestForm(true)}
+          className="gap-2 w-full sm:w-auto"
+        >
+          <ShoppingBag className="h-4 w-4" />
+          Pedir Serviço
+        </Button>
+      ) : (
+        <div className="rounded-lg border p-4 space-y-3 bg-muted/30">
+          <h3 className="text-sm font-semibold">Enviar pedido</h3>
+          <div className="space-y-1">
+            <Label htmlFor="request-message">Mensagem para o prestador</Label>
+            <Textarea
+              id="request-message"
+              rows={4}
+              placeholder="Descreve o que precisas, quando, ou qualquer detalhe relevante..."
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              className="resize-none"
+            />
+            <p className="text-xs text-muted-foreground">Mínimo 10 caracteres.</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button onClick={handleRequest} disabled={isSubmitting} size="sm">
+              {isSubmitting ? 'A enviar...' : 'Enviar pedido'}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => { setShowRequestForm(false); setMessage('') }}
+              disabled={isSubmitting}
+              size="sm"
+            >
+              Cancelar
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/services/service-card.tsx
+++ b/src/components/services/service-card.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardFooter } from '@/components/ui/card'
+import { Star, Euro } from 'lucide-react'
+
+interface ServiceCardProps {
+  service: {
+    id: string
+    title: string
+    price: number
+    category: { name: string } | null
+    user: {
+      id: string
+      name: string
+      avatarUrl: string | null
+      rating: number
+    }
+  }
+}
+
+function getInitials(name: string): string {
+  return name.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
+}
+
+export function ServiceCard({ service }: ServiceCardProps) {
+  return (
+    <Link href={`/services/${service.id}`} className="group">
+      <Card className="h-full transition-shadow hover:shadow-md">
+        <CardContent className="space-y-2">
+          {service.category && (
+            <Badge variant="secondary" className="text-xs">{service.category.name}</Badge>
+          )}
+          <h3 className="font-semibold leading-snug line-clamp-2 group-hover:text-primary transition-colors">
+            {service.title}
+          </h3>
+          <div className="flex items-center gap-0.5 text-lg font-bold text-primary">
+            <Euro className="h-4 w-4" />
+            {service.price.toFixed(2)}
+          </div>
+        </CardContent>
+        <CardFooter className="gap-0">
+          <div className="flex items-center justify-between w-full">
+            <div className="flex items-center gap-2 min-w-0">
+              <Avatar className="size-6 shrink-0">
+                <AvatarImage src={service.user.avatarUrl ?? undefined} alt={service.user.name} />
+                <AvatarFallback className="text-[10px]">{getInitials(service.user.name)}</AvatarFallback>
+              </Avatar>
+              <span className="text-sm text-muted-foreground truncate">
+                {service.user.name.split(' ')[0]}
+              </span>
+            </div>
+            {service.user.rating > 0 && (
+              <div className="flex items-center gap-1 text-sm shrink-0">
+                <Star className="h-3.5 w-3.5 fill-yellow-400 text-yellow-400" />
+                <span className="font-medium">{service.user.rating.toFixed(1)}</span>
+              </div>
+            )}
+          </div>
+        </CardFooter>
+      </Card>
+    </Link>
+  )
+}

--- a/src/components/services/services-filters.tsx
+++ b/src/components/services/services-filters.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useCallback, useRef } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Search } from 'lucide-react'
+
+interface Category {
+  id: string
+  name: string
+}
+
+interface ServicesFiltersProps {
+  categories: Category[]
+}
+
+export function ServicesFilters({ categories }: ServicesFiltersProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const buildUrl = useCallback(
+    (updates: Record<string, string>) => {
+      const params = new URLSearchParams(searchParams.toString())
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value) {
+          params.set(key, value)
+        } else {
+          params.delete(key)
+        }
+      })
+      params.delete('page')
+      return `/services?${params.toString()}`
+    },
+    [searchParams],
+  )
+
+  function handleSearchSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const q = searchInputRef.current?.value ?? ''
+    router.push(buildUrl({ q }))
+  }
+
+  function handleSelectChange(key: string, value: string | null) {
+    const v = value ?? ''
+    router.push(buildUrl({ [key]: v === '_all' ? '' : v }))
+  }
+
+  function handleMaxPriceBlur(e: React.FocusEvent<HTMLInputElement>) {
+    router.push(buildUrl({ maxPrice: e.target.value }))
+  }
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      {/* Pesquisa por texto */}
+      <form onSubmit={handleSearchSubmit} className="flex gap-2">
+        <Input
+          ref={searchInputRef}
+          name="q"
+          placeholder="Pesquisar serviços..."
+          defaultValue={searchParams.get('q') ?? ''}
+          className="w-56"
+          aria-label="Pesquisar serviços"
+        />
+        <Button type="submit" size="icon" variant="secondary" aria-label="Pesquisar">
+          <Search className="h-4 w-4" />
+        </Button>
+      </form>
+
+      {/* Categoria */}
+      <Select
+        value={searchParams.get('categoryId') ?? '_all'}
+        onValueChange={(v) => handleSelectChange('categoryId', v)}
+      >
+        <SelectTrigger className="w-44" aria-label="Filtrar por categoria">
+          <SelectValue placeholder="Categoria" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="_all">Todas as categorias</SelectItem>
+          {categories.map((cat) => (
+            <SelectItem key={cat.id} value={cat.id}>
+              {cat.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Preço máximo */}
+      <Input
+        type="number"
+        min="0"
+        step="0.01"
+        placeholder="Preço máx. (€)"
+        defaultValue={searchParams.get('maxPrice') ?? ''}
+        onBlur={handleMaxPriceBlur}
+        className="w-36"
+        aria-label="Preço máximo"
+      />
+
+      {/* Ordenação */}
+      <Select
+        value={searchParams.get('sort') ?? 'newest'}
+        onValueChange={(v) => handleSelectChange('sort', v)}
+      >
+        <SelectTrigger className="w-44" aria-label="Ordenar por">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="newest">Mais recente</SelectItem>
+          <SelectItem value="price_asc">Preço ↑</SelectItem>
+          <SelectItem value="rating">Melhor avaliado</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}


### PR DESCRIPTION
## Resumo

- **US-008** — Página pública `/services` com SSR, filtros via URL, paginação
- **US-009** — Página `/services/[id]` pública com reviews, botões de ação contextuais e endpoint de pedidos

## Alterações

### Novos ficheiros
- `src/app/(main)/services/page.tsx` — listagem SSR com searchParams
- `src/components/services/service-card.tsx` — card com título, categoria, preço, rating + avatar do prestador
- `src/components/services/services-filters.tsx` — componente client que gere a URL como fonte de verdade dos filtros
- `src/components/services/service-actions.tsx` — botões contextuais (owner/autenticado/anónimo)
- `src/app/api/requests/route.ts` — POST endpoint para criar pedidos de serviço

### Ficheiros modificados
- `src/app/(main)/services/[id]/page.tsx` — reviews, badge de disponibilidade, rating médio, ServiceActions

## Comportamento dos filtros (`/services`)

| Filtro | Mecanismo |
|--------|-----------|
| Pesquisa (`q`) | Input + submit por Enter |
| Categoria | Select com atualização imediata |
| Preço máximo | Input numérico, atualiza no blur |
| Ordenação | Select: mais recente / preço ↑ / melhor avaliado |

A paginação é prev/next com URL como fonte de verdade. Ao mudar qualquer filtro, o `page` é resetado.

## Botões de ação (`/services/[id]`)

| Estado do utilizador | Comportamento |
|----------------------|---------------|
| Não autenticado | "Pedir Serviço" → `/login?callbackUrl=/services/[id]` |
| Autenticado, não-dono | "Pedir Serviço" → formulário inline com mensagem |
| Dono do serviço | "Editar" + "Remover" com confirmação inline |

## Plano de testes

- [ ] `/services` carrega sem login
- [ ] Pesquisa por texto filtra por título e descrição
- [ ] Filtro de categoria funciona
- [ ] Filtro de preço máximo funciona
- [ ] Ordenação por preço ↑ funciona
- [ ] Paginação prev/next funciona e mantém filtros
- [ ] URL reflecte todos os filtros ativos
- [ ] `/services/[id]` mostra disponibilidade correta
- [ ] Anónimo clica "Pedir Serviço" → redireciona para login com callbackUrl
- [ ] Autenticado não-dono pode submeter pedido com mensagem
- [ ] Dono vê "Editar" e "Remover" em vez do botão de pedido
- [ ] "Remover" pede confirmação antes de apagar
- [ ] Reviews aparecem com rating por estrelas, nome do cliente e data
- [ ] POST `/api/requests` rejeita pedido duplicado pendente (409)
- [ ] POST `/api/requests` rejeita pedido ao próprio serviço (400)

Closes #8, #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)