### PR TITLE
feat(requests): US-010 + US-011 + US-012 — gestão completa de pedidos

### DIFF
--- a/src/actions/requests.ts
+++ b/src/actions/requests.ts
@@ -1,0 +1,106 @@
+'use server'
+
+import { auth } from '@/auth'
+import { prisma } from '@/lib/prisma'
+import { revalidatePath } from 'next/cache'
+import type { RequestStatus } from '@prisma/client'
+
+type ActionResult = { success: true } | { success: false; error: string }
+
+async function transitionRequest(
+  requestId: string,
+  expectedStatus: RequestStatus,
+  newStatus: RequestStatus,
+  ownerField: 'provider' | 'buyer',
+): Promise<ActionResult> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { success: false, error: 'Não autenticado.' }
+  }
+
+  const request = await prisma.serviceRequest.findUnique({
+    where: { id: requestId },
+    select: {
+      id: true,
+      status: true,
+      buyerId: true,
+      service: { select: { userId: true } },
+    },
+  })
+
+  if (!request) {
+    return { success: false, error: 'Pedido não encontrado.' }
+  }
+
+  if (request.status !== expectedStatus) {
+    return { success: false, error: 'Transição de estado inválida.' }
+  }
+
+  const userId = session.user.id
+  if (ownerField === 'provider' && request.service.userId !== userId) {
+    return { success: false, error: 'Sem permissão.' }
+  }
+  if (ownerField === 'buyer' && request.buyerId !== userId) {
+    return { success: false, error: 'Sem permissão.' }
+  }
+
+  await prisma.serviceRequest.update({
+    where: { id: requestId },
+    data: { status: newStatus },
+  })
+
+  revalidatePath('/dashboard/requests')
+  revalidatePath('/dashboard/my-requests')
+
+  return { success: true }
+}
+
+/** PENDING → ACCEPTED (provider) */
+export async function acceptRequest(requestId: string): Promise<ActionResult> {
+  return transitionRequest(requestId, 'PENDING', 'ACCEPTED', 'provider')
+}
+
+/** PENDING → REJECTED (provider) */
+export async function rejectRequest(requestId: string): Promise<ActionResult> {
+  return transitionRequest(requestId, 'PENDING', 'REJECTED', 'provider')
+}
+
+/** ACCEPTED → COMPLETED (provider) */
+export async function completeRequest(requestId: string): Promise<ActionResult> {
+  return transitionRequest(requestId, 'ACCEPTED', 'COMPLETED', 'provider')
+}
+
+/** PENDING | ACCEPTED → CANCELLED (buyer) */
+export async function cancelRequest(requestId: string): Promise<ActionResult> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { success: false, error: 'Não autenticado.' }
+  }
+
+  const request = await prisma.serviceRequest.findUnique({
+    where: { id: requestId },
+    select: { id: true, status: true, buyerId: true },
+  })
+
+  if (!request) {
+    return { success: false, error: 'Pedido não encontrado.' }
+  }
+
+  if (request.status !== 'PENDING' && request.status !== 'ACCEPTED') {
+    return { success: false, error: 'Este pedido não pode ser cancelado.' }
+  }
+
+  if (request.buyerId !== session.user.id) {
+    return { success: false, error: 'Sem permissão.' }
+  }
+
+  await prisma.serviceRequest.update({
+    where: { id: requestId },
+    data: { status: 'CANCELLED' },
+  })
+
+  revalidatePath('/dashboard/requests')
+  revalidatePath('/dashboard/my-requests')
+
+  return { success: true }
+}

--- a/src/app/(main)/dashboard/my-requests/page.tsx
+++ b/src/app/(main)/dashboard/my-requests/page.tsx
@@ -1,0 +1,81 @@
+import { Suspense } from 'react'
+import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { auth } from '@/auth'
+import { prisma } from '@/lib/prisma'
+import { SentRequestCard } from '@/components/requests/sent-request-card'
+import { RequestStatusFilter } from '@/components/requests/request-status-filter'
+import type { RequestStatus } from '@prisma/client'
+
+export const metadata: Metadata = {
+  title: 'Os meus pedidos — SkoolBay',
+}
+
+const VALID_STATUSES = new Set<RequestStatus>([
+  'PENDING',
+  'ACCEPTED',
+  'COMPLETED',
+  'REJECTED',
+  'CANCELLED',
+])
+
+interface PageProps {
+  searchParams: { status?: string }
+}
+
+export default async function MyRequestsPage({ searchParams }: PageProps) {
+  const session = await auth()
+  if (!session?.user?.id) redirect('/login?callbackUrl=/dashboard/my-requests')
+
+  const rawStatus = searchParams.status
+  const statusFilter =
+    rawStatus && VALID_STATUSES.has(rawStatus as RequestStatus)
+      ? (rawStatus as RequestStatus)
+      : undefined
+
+  const requests = await prisma.serviceRequest.findMany({
+    where: {
+      buyerId: session.user.id,
+      ...(statusFilter && { status: statusFilter }),
+    },
+    orderBy: { updatedAt: 'desc' },
+    select: {
+      id: true,
+      message: true,
+      status: true,
+      createdAt: true,
+      service: {
+        select: {
+          id: true,
+          title: true,
+          user: { select: { id: true, name: true, avatarUrl: true } },
+        },
+      },
+    },
+  })
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10">
+      <div className="mb-6 space-y-1">
+        <h1 className="text-2xl font-bold">Os meus pedidos</h1>
+        <p className="text-muted-foreground text-sm">Pedidos que enviaste a prestadores</p>
+      </div>
+
+      <Suspense fallback={null}>
+        <RequestStatusFilter basePath="/dashboard/my-requests" />
+      </Suspense>
+
+      <div className="mt-6 space-y-3">
+        {requests.length === 0 ? (
+          <p className="py-12 text-center text-sm text-muted-foreground">
+            {statusFilter ? 'Nenhum pedido com este estado.' : 'Ainda não enviaste nenhum pedido.'}
+          </p>
+        ) : (
+          requests.map((request) => (
+            <SentRequestCard key={request.id} request={request} />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,14 +1,108 @@
-import { auth } from '@/auth'
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { auth } from '@/auth'
+import { prisma } from '@/lib/prisma'
+import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { Inbox, SendHorizonal, Plus } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'Dashboard — SkoolBay',
+}
 
 export default async function DashboardPage() {
   const session = await auth()
-  if (!session) redirect('/login')
+  if (!session?.user?.id) redirect('/login')
+
+  const [receivedCount, sentCount] = await Promise.all([
+    prisma.serviceRequest.count({
+      where: { service: { userId: session.user.id }, status: 'PENDING' },
+    }),
+    prisma.serviceRequest.count({
+      where: { buyerId: session.user.id, status: 'PENDING' },
+    }),
+  ])
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-2">Olá, {session.user?.name?.split(' ')[0]}!</h1>
-      <p className="text-muted-foreground">O teu dashboard está a ser construído. Volta em breve.</p>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold mb-1">
+          Olá, {session.user?.name?.split(' ')[0]}!
+        </h1>
+        <p className="text-muted-foreground text-sm">O que queres fazer hoje?</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {/* Pedidos recebidos */}
+        <Link
+          href="/dashboard/requests"
+          className="group flex flex-col gap-3 rounded-xl border bg-card p-5 text-sm transition-shadow hover:shadow-md"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+              <Inbox className="h-5 w-5 text-primary" />
+            </div>
+            {receivedCount > 0 && (
+              <span className="inline-flex h-5 items-center rounded-full bg-primary px-2 text-xs font-medium text-primary-foreground">
+                {receivedCount}
+              </span>
+            )}
+          </div>
+          <div>
+            <p className="font-semibold group-hover:text-primary transition-colors">
+              Pedidos recebidos
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Gere os pedidos nos teus serviços
+            </p>
+          </div>
+        </Link>
+
+        {/* Pedidos enviados */}
+        <Link
+          href="/dashboard/my-requests"
+          className="group flex flex-col gap-3 rounded-xl border bg-card p-5 text-sm transition-shadow hover:shadow-md"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-secondary">
+              <SendHorizonal className="h-5 w-5 text-secondary-foreground" />
+            </div>
+            {sentCount > 0 && (
+              <span className="inline-flex h-5 items-center rounded-full bg-secondary px-2 text-xs font-medium text-secondary-foreground">
+                {sentCount}
+              </span>
+            )}
+          </div>
+          <div>
+            <p className="font-semibold group-hover:text-primary transition-colors">
+              Os meus pedidos
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Acompanha os pedidos que enviaste
+            </p>
+          </div>
+        </Link>
+
+        {/* Publicar serviço */}
+        <Link
+          href="/services/new"
+          className={cn(
+            buttonVariants({ variant: 'outline' }),
+            'group flex flex-col items-start gap-3 rounded-xl h-auto p-5 text-sm',
+          )}
+        >
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg border-2 border-dashed border-muted-foreground/30 group-hover:border-primary/50 transition-colors">
+            <Plus className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
+          </div>
+          <div>
+            <p className="font-semibold">Publicar serviço</p>
+            <p className="text-xs text-muted-foreground mt-0.5 font-normal">
+              Oferece os teus conhecimentos
+            </p>
+          </div>
+        </Link>
+      </div>
     </div>
   )
 }

--- a/src/app/(main)/dashboard/requests/page.tsx
+++ b/src/app/(main)/dashboard/requests/page.tsx
@@ -1,0 +1,85 @@
+import { Suspense } from 'react'
+import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { auth } from '@/auth'
+import { prisma } from '@/lib/prisma'
+import { ReceivedRequestCard } from '@/components/requests/received-request-card'
+import { RequestStatusFilter } from '@/components/requests/request-status-filter'
+import type { RequestStatus } from '@prisma/client'
+
+export const metadata: Metadata = {
+  title: 'Pedidos recebidos — SkoolBay',
+}
+
+const VALID_STATUSES = new Set<RequestStatus>([
+  'PENDING',
+  'ACCEPTED',
+  'COMPLETED',
+  'REJECTED',
+  'CANCELLED',
+])
+
+interface PageProps {
+  searchParams: { status?: string }
+}
+
+export default async function ReceivedRequestsPage({ searchParams }: PageProps) {
+  const session = await auth()
+  if (!session?.user?.id) redirect('/login?callbackUrl=/dashboard/requests')
+
+  const rawStatus = searchParams.status
+  const statusFilter =
+    rawStatus && VALID_STATUSES.has(rawStatus as RequestStatus)
+      ? (rawStatus as RequestStatus)
+      : undefined
+
+  const requests = await prisma.serviceRequest.findMany({
+    where: {
+      service: { userId: session.user.id },
+      ...(statusFilter && { status: statusFilter }),
+    },
+    orderBy: { updatedAt: 'desc' },
+    select: {
+      id: true,
+      message: true,
+      status: true,
+      createdAt: true,
+      service: { select: { id: true, title: true } },
+      buyer: { select: { id: true, name: true, avatarUrl: true } },
+    },
+  })
+
+  const pendingCount = requests.filter((r) => r.status === 'PENDING').length
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10">
+      <div className="mb-6 space-y-1">
+        <h1 className="text-2xl font-bold">Pedidos recebidos</h1>
+        <p className="text-muted-foreground text-sm">
+          Pedidos nos teus serviços
+          {pendingCount > 0 && (
+            <span className="ml-2 inline-flex h-5 items-center rounded-full bg-primary px-2 text-xs font-medium text-primary-foreground">
+              {pendingCount} pendente{pendingCount !== 1 && 's'}
+            </span>
+          )}
+        </p>
+      </div>
+
+      <Suspense fallback={null}>
+        <RequestStatusFilter basePath="/dashboard/requests" />
+      </Suspense>
+
+      <div className="mt-6 space-y-3">
+        {requests.length === 0 ? (
+          <p className="py-12 text-center text-sm text-muted-foreground">
+            {statusFilter ? 'Nenhum pedido com este estado.' : 'Ainda não tens pedidos recebidos.'}
+          </p>
+        ) : (
+          requests.map((request) => (
+            <ReceivedRequestCard key={request.id} request={request} />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/requests/received-request-card.tsx
+++ b/src/components/requests/received-request-card.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useTransition } from 'react'
+import Link from 'next/link'
+import { toast } from 'sonner'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import { RequestStatusBadge } from './request-status-badge'
+import { acceptRequest, rejectRequest, completeRequest } from '@/actions/requests'
+import { Check, X, CheckCheck, ExternalLink } from 'lucide-react'
+import type { RequestStatus } from '@prisma/client'
+
+interface ReceivedRequestCardProps {
+  request: {
+    id: string
+    message: string
+    status: RequestStatus
+    createdAt: Date
+    service: { id: string; title: string }
+    buyer: { id: string; name: string; avatarUrl: string | null }
+  }
+}
+
+function getInitials(name: string): string {
+  return name.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
+}
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('pt-PT', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(date))
+}
+
+export function ReceivedRequestCard({ request }: ReceivedRequestCardProps) {
+  const [isPending, startTransition] = useTransition()
+
+  function handleAction(action: () => Promise<{ success: boolean; error?: string }>) {
+    startTransition(async () => {
+      const result = await action()
+      if (!result.success) {
+        toast.error(result.error ?? 'Erro ao atualizar pedido.')
+      }
+    })
+  }
+
+  return (
+    <div className="rounded-xl border bg-card p-4 space-y-3 text-sm">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <Avatar className="size-8 shrink-0">
+            <AvatarImage src={request.buyer.avatarUrl ?? undefined} alt={request.buyer.name} />
+            <AvatarFallback className="text-xs">{getInitials(request.buyer.name)}</AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className="font-medium truncate">{request.buyer.name}</p>
+            <p className="text-xs text-muted-foreground">{formatDate(request.createdAt)}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <RequestStatusBadge status={request.status} />
+        </div>
+      </div>
+
+      {/* Serviço */}
+      <Link
+        href={`/services/${request.service.id}`}
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors w-fit"
+      >
+        <ExternalLink className="h-3 w-3" />
+        {request.service.title}
+      </Link>
+
+      {/* Mensagem */}
+      <p className="text-muted-foreground leading-relaxed line-clamp-3">{request.message}</p>
+
+      {/* Ações */}
+      {request.status === 'PENDING' && (
+        <div className="flex items-center gap-2 pt-1">
+          <Button
+            size="sm"
+            onClick={() => handleAction(() => acceptRequest(request.id))}
+            disabled={isPending}
+            className="gap-1"
+          >
+            <Check className="h-3.5 w-3.5" />
+            Aceitar
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={() => handleAction(() => rejectRequest(request.id))}
+            disabled={isPending}
+            className="gap-1"
+          >
+            <X className="h-3.5 w-3.5" />
+            Recusar
+          </Button>
+        </div>
+      )}
+
+      {request.status === 'ACCEPTED' && (
+        <div className="flex items-center gap-2 pt-1">
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => handleAction(() => completeRequest(request.id))}
+            disabled={isPending}
+            className="gap-1"
+          >
+            <CheckCheck className="h-3.5 w-3.5" />
+            Marcar como concluído
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/requests/request-status-badge.tsx
+++ b/src/components/requests/request-status-badge.tsx
@@ -1,0 +1,43 @@
+import { Badge } from '@/components/ui/badge'
+import type { RequestStatus } from '@prisma/client'
+
+const STATUS_MAP: Record<RequestStatus, { label: string; className: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }> = {
+  PENDING: {
+    label: 'Pendente',
+    className: '',
+    variant: 'secondary',
+  },
+  ACCEPTED: {
+    label: 'Aceite',
+    className: 'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/30 dark:text-blue-400',
+    variant: 'outline',
+  },
+  COMPLETED: {
+    label: 'Concluído',
+    className: 'bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400',
+    variant: 'outline',
+  },
+  REJECTED: {
+    label: 'Recusado',
+    className: '',
+    variant: 'destructive',
+  },
+  CANCELLED: {
+    label: 'Cancelado',
+    className: 'text-muted-foreground',
+    variant: 'outline',
+  },
+}
+
+interface RequestStatusBadgeProps {
+  status: RequestStatus
+}
+
+export function RequestStatusBadge({ status }: RequestStatusBadgeProps) {
+  const { label, className, variant } = STATUS_MAP[status]
+  return (
+    <Badge variant={variant} className={className}>
+      {label}
+    </Badge>
+  )
+}

--- a/src/components/requests/request-status-filter.tsx
+++ b/src/components/requests/request-status-filter.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import type { RequestStatus } from '@prisma/client'
+
+const FILTER_OPTIONS: { value: RequestStatus | '_all'; label: string }[] = [
+  { value: '_all', label: 'Todos' },
+  { value: 'PENDING', label: 'Pendentes' },
+  { value: 'ACCEPTED', label: 'Aceites' },
+  { value: 'COMPLETED', label: 'Concluídos' },
+  { value: 'REJECTED', label: 'Recusados' },
+  { value: 'CANCELLED', label: 'Cancelados' },
+]
+
+interface RequestStatusFilterProps {
+  basePath: string
+}
+
+export function RequestStatusFilter({ basePath }: RequestStatusFilterProps) {
+  const searchParams = useSearchParams()
+  const current = searchParams.get('status') ?? '_all'
+
+  return (
+    <div className="flex flex-wrap gap-1.5" role="tablist" aria-label="Filtrar por estado">
+      {FILTER_OPTIONS.map(({ value, label }) => {
+        const href =
+          value === '_all' ? basePath : `${basePath}?status=${value}`
+        const isActive = current === value
+
+        return (
+          <Link
+            key={value}
+            href={href}
+            role="tab"
+            aria-selected={isActive}
+            className={cn(
+              'inline-flex h-7 items-center rounded-lg px-2.5 text-sm font-medium transition-colors',
+              isActive
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+            )}
+          >
+            {label}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/requests/sent-request-card.tsx
+++ b/src/components/requests/sent-request-card.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useTransition } from 'react'
+import Link from 'next/link'
+import { toast } from 'sonner'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import { RequestStatusBadge } from './request-status-badge'
+import { cancelRequest } from '@/actions/requests'
+import { ExternalLink, User, XCircle } from 'lucide-react'
+import type { RequestStatus } from '@prisma/client'
+
+interface SentRequestCardProps {
+  request: {
+    id: string
+    message: string
+    status: RequestStatus
+    createdAt: Date
+    service: {
+      id: string
+      title: string
+      user: { id: string; name: string; avatarUrl: string | null }
+    }
+  }
+}
+
+function getInitials(name: string): string {
+  return name.split(' ').slice(0, 2).map((n) => n[0]).join('').toUpperCase()
+}
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('pt-PT', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(date))
+}
+
+export function SentRequestCard({ request }: SentRequestCardProps) {
+  const [isPending, startTransition] = useTransition()
+  const canCancel = request.status === 'PENDING' || request.status === 'ACCEPTED'
+
+  function handleCancel() {
+    startTransition(async () => {
+      const result = await cancelRequest(request.id)
+      if (!result.success) {
+        toast.error(result.error ?? 'Erro ao cancelar pedido.')
+      } else {
+        toast.success('Pedido cancelado.')
+      }
+    })
+  }
+
+  return (
+    <div className="rounded-xl border bg-card p-4 space-y-3 text-sm">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <Link
+            href={`/services/${request.service.id}`}
+            className="font-medium hover:text-primary transition-colors flex items-center gap-1 w-fit"
+          >
+            {request.service.title}
+            <ExternalLink className="h-3 w-3 shrink-0" />
+          </Link>
+          <p className="text-xs text-muted-foreground mt-0.5">{formatDate(request.createdAt)}</p>
+        </div>
+        <RequestStatusBadge status={request.status} />
+      </div>
+
+      {/* Prestador */}
+      <Link
+        href={`/profile/${request.service.user.id}`}
+        className="flex items-center gap-2 w-fit group"
+      >
+        <Avatar className="size-6 shrink-0">
+          <AvatarImage
+            src={request.service.user.avatarUrl ?? undefined}
+            alt={request.service.user.name}
+          />
+          <AvatarFallback className="text-[10px]">
+            {getInitials(request.service.user.name)}
+          </AvatarFallback>
+        </Avatar>
+        <span className="text-xs text-muted-foreground group-hover:text-foreground transition-colors flex items-center gap-1">
+          <User className="h-3 w-3" />
+          {request.service.user.name}
+        </span>
+      </Link>
+
+      {/* Mensagem */}
+      <p className="text-muted-foreground leading-relaxed line-clamp-3">{request.message}</p>
+
+      {/* Cancelar */}
+      {canCancel && (
+        <div className="pt-1">
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={handleCancel}
+            disabled={isPending}
+            className="gap-1"
+          >
+            <XCircle className="h-3.5 w-3.5" />
+            {isPending ? 'A cancelar...' : 'Cancelar pedido'}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Resumo

- **US-010** — Enviar pedido de serviço (endpoint já existia, fluxo completo validado)
- **US-011** — Gerir pedidos recebidos como prestador (`/dashboard/requests`)
- **US-012** — Ver e cancelar pedidos enviados como cliente (`/dashboard/my-requests`)

## Ficheiros novos

| Ficheiro | Responsabilidade |
|----------|-----------------|
| `src/actions/requests.ts` | Server Actions: `acceptRequest`, `rejectRequest`, `completeRequest`, `cancelRequest` |
| `src/components/requests/request-status-badge.tsx` | Badge partilhado com cor semântica por estado |
| `src/components/requests/request-status-filter.tsx` | Tabs de filtro client-side (URL como fonte de verdade) |
| `src/components/requests/received-request-card.tsx` | Card com botões de ação para o prestador |
| `src/components/requests/sent-request-card.tsx` | Card com botão cancelar para o cliente |
| `src/app/(main)/dashboard/requests/page.tsx` | US-011: pedidos recebidos (SSR + searchParams) |
| `src/app/(main)/dashboard/my-requests/page.tsx` | US-012: pedidos enviados (SSR + searchParams) |

## Transições de estado

```
PENDING  →  ACCEPTED    (provider: Aceitar)
PENDING  →  REJECTED    (provider: Recusar)
ACCEPTED →  COMPLETED   (provider: Concluído)
PENDING  →  CANCELLED   (buyer: Cancelar)
ACCEPTED →  CANCELLED   (buyer: Cancelar)
```

Todas as transições são validadas no servidor com verificação de ownership. Chamadas client-side via `useTransition` + toast.

## Dashboard

O `/dashboard` foi atualizado com cards de navegação rápida e contadores de pedidos pendentes em tempo real (SSR).

## Plano de testes

- [ ] Provider vê pedidos recebidos nos seus serviços
- [ ] Filtro por estado funciona e mantém-se na URL
- [ ] Provider aceita pedido PENDING → fica ACCEPTED
- [ ] Provider recusa pedido PENDING → fica REJECTED
- [ ] Provider conclui pedido ACCEPTED → fica COMPLETED
- [ ] Buyer vê os seus pedidos enviados com estados correctos
- [ ] Buyer cancela pedido PENDING → fica CANCELLED
- [ ] Buyer cancela pedido ACCEPTED → fica CANCELLED
- [ ] Botão cancelar não aparece para pedidos COMPLETED/REJECTED/CANCELLED
- [ ] Botões de ação do prestador não aparecem para estados terminais
- [ ] Dashboard mostra contadores de pendentes correctos
- [ ] Acesso sem sessão redireciona para login com callbackUrl

Closes #10, #11, #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)